### PR TITLE
Audit logs aren't instantly updated on demotion

### DIFF
--- a/.github/workflows/manual-demotion-workflow.yml
+++ b/.github/workflows/manual-demotion-workflow.yml
@@ -63,6 +63,10 @@ jobs:
           mkdir -p reports
           ls -Fla
 
+      - name: Sleep to allow audit logs to catch up
+        run: |
+          sleep 30
+
       - name: Report admin operations
         id: report_admin_ops
         uses: ./admin-support-cli


### PR DESCRIPTION
- Add a sleep to let the audit log catch up before generating the report or you might miss the demotion event in the report.